### PR TITLE
Fix Ilkley Moor walk route and coordinates

### DIFF
--- a/ilkley-moor/index.html
+++ b/ilkley-moor/index.html
@@ -162,8 +162,7 @@ const MAIN_ROUTE = [
     [53.9133, -1.7968],  // Cow and Calf pub (lunch)
     [53.9110, -1.8060],  // head back south-west
     [53.9095, -1.8165],  // Ilkley Tarn
-    [53.9165, -1.8237],  // back past White Wells
-    [53.9213, -1.8224]   // car park
+    [53.9213, -1.8224]   // back to the car park
 ];
 
 // Optional detour: out-and-back to the Twelve Apostles from the moor edge.

--- a/ilkley-moor/index.html
+++ b/ilkley-moor/index.html
@@ -116,37 +116,43 @@
 const POINTS = [
     {
         name: 'Car park (Wells Road)',
-        coord: [53.9213, -1.8224],
+        coord: [53.92056085831621, -1.8224139463040103],
         desc: 'Start / finish. Parking on Wells Road, near Darwin Gardens.',
         photos: []
     },
     {
         name: 'White Wells',
-        coord: [53.9165, -1.8237],
+        coord: [53.91691763324235, -1.8217285358356037],
         desc: 'Historic spa bath house on the lower moor.',
         photos: []
     },
     {
+        name: 'Edge of the moor',
+        coord: [53.913502572513295, -1.8134656867894137],
+        desc: 'The optional detour to the Twelve Apostles branches off here.',
+        photos: []
+    },
+    {
         name: 'Twelve Apostles stone circle',
-        coord: [53.9008, -1.8079],
+        coord: [53.90158203875271, -1.8095389705668197],
         desc: 'Optional detour: a Bronze Age stone circle on the moor top, then back.',
         photos: []
     },
     {
         name: 'Cow and Calf rocks',
-        coord: [53.9128, -1.7957],
+        coord: [53.91704186761535, -1.8026018676202966],
         desc: 'Dramatic gritstone outcrop, popular with climbers.',
         photos: []
     },
     {
         name: 'Cow and Calf (pub)',
-        coord: [53.9133, -1.7968],
+        coord: [53.91656426785184, -1.8001808559926928],
         desc: 'Lunch stop.',
         photos: []
     },
     {
         name: 'Ilkley Tarn',
-        coord: [53.9095, -1.8165],
+        coord: [53.91897412411697, -1.815925004696794],
         desc: 'Quiet moorland tarn on the way back down.',
         photos: []
     }
@@ -154,21 +160,19 @@ const POINTS = [
 
 // Main circular route (ordered list of waypoints).
 const MAIN_ROUTE = [
-    [53.9213, -1.8224],  // car park
-    [53.9165, -1.8237],  // White Wells
-    [53.9120, -1.8205],  // edge of the moors
-    [53.9118, -1.8050],  // traverse east along the moor edge
-    [53.9128, -1.7957],  // Cow and Calf rocks
-    [53.9133, -1.7968],  // Cow and Calf pub (lunch)
-    [53.9110, -1.8060],  // head back south-west
-    [53.9095, -1.8165],  // Ilkley Tarn
-    [53.9213, -1.8224]   // back to the car park
+    [53.92056085831621, -1.8224139463040103],  // car park
+    [53.91691763324235, -1.8217285358356037],  // White Wells
+    [53.913502572513295, -1.8134656867894137], // edge of the moor
+    [53.91704186761535, -1.8026018676202966],  // Cow and Calf rocks
+    [53.91656426785184, -1.8001808559926928],  // Cow and Calf pub (lunch)
+    [53.91897412411697, -1.815925004696794],   // Ilkley Tarn
+    [53.92056085831621, -1.8224139463040103]   // back to the car park
 ];
 
 // Optional detour: out-and-back to the Twelve Apostles from the moor edge.
 const DETOUR_ROUTE = [
-    [53.9120, -1.8205],  // leave the main route at the moor edge
-    [53.9008, -1.8079]   // Twelve Apostles (return by the same path)
+    [53.913502572513295, -1.8134656867894137], // leave the main route at the moor edge
+    [53.90158203875271, -1.8095389705668197]   // Twelve Apostles (return by the same path)
 ];
 
 /* ------------------------------------------------------------------ *


### PR DESCRIPTION
Follow-up to #2, with the two refinements that landed after it merged:

- Close the loop directly from Ilkley Tarn back to the car park, instead of bending to the second marker (White Wells).
- Reposition every marker and the route onto the surveyed coordinates dropped in geojson.io, and add an "Edge of the moor" marker at the junction where the optional Twelve Apostles detour branches off.

Route legs are straight lines between waypoints. Approximate distances: main loop ~3.6 km, Twelve Apostles detour +2.7 km (out and back), ~6.3 km total.

https://claude.ai/code/session_01KqQRP7XFVK3yEs6vD6EPBF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqQRP7XFVK3yEs6vD6EPBF)_