### PR TITLE
Correct walk direction to anticlockwise

### DIFF
--- a/ilkley-moor/index.html
+++ b/ilkley-moor/index.html
@@ -95,7 +95,7 @@
     <h1>Ilkley Moor Walk</h1>
     <p>A circular walk from Wells Road up over the moor, taking in White Wells,
        the Cow and Calf, and Ilkley Tarn. Click the markers for details.</p>
-    <p class="dir">Walk <b>clockwise</b> &#8635;</p>
+    <p class="dir">Walk <b>anticlockwise</b> &#8634;</p>
 </div>
 
 <div id="legend" class="panel">
@@ -125,7 +125,7 @@ const POINTS = [
     {
         name: 'Car park (Wells Road)',
         coord: [53.92056085831621, -1.8224139463040103],
-        desc: 'Start / finish. Parking on Wells Road, near Darwin Gardens. The walk goes clockwise.',
+        desc: 'Start / finish. Parking on Wells Road, near Darwin Gardens. The walk goes anticlockwise.',
         start: true,
         photos: []
     },


### PR DESCRIPTION
Corrects the stated walk direction from clockwise to **anticlockwise** in both the title panel (with the matching &#8634; arrow) and the car park popup. The loop order itself is unchanged — only the label.

https://claude.ai/code/session_01KqQRP7XFVK3yEs6vD6EPBF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqQRP7XFVK3yEs6vD6EPBF)_